### PR TITLE
Improve endless scroll smoothness and image loading

### DIFF
--- a/src/components/QuoteCard.tsx
+++ b/src/components/QuoteCard.tsx
@@ -14,7 +14,7 @@ interface QuoteCardProps {
 // have not changed. This is crucial for performance, especially if the parent component
 // re-renders frequently, as it avoids re-calculating animations and styles for visible cards.
 export const QuoteCard: React.FC<QuoteCardProps> = React.memo(({ quote, className }) => {
-  const { imageData, loading } = useImageBackground(quote);
+  const { imageData, isLoaded } = useImageBackground(quote);
   const [isVisible, setIsVisible] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
 
@@ -50,13 +50,18 @@ export const QuoteCard: React.FC<QuoteCardProps> = React.memo(({ quote, classNam
         'relative overflow-hidden rounded-3xl p-8 md:p-12 text-white min-h-[400px] md:min-h-[450px] flex flex-col justify-center items-center text-center shadow-2xl transition-all duration-500 hover:shadow-3xl hover:scale-[1.02] active:scale-[0.98]',
         className
       )}
-      style={{
-        backgroundImage: imageData ? `url(${imageData.url})` : undefined,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat',
-      }}
     >
+      {/* Background image layer with smooth fade-in */}
+      <div
+        className={cn(
+          'absolute inset-0 bg-cover bg-center transition-opacity duration-700',
+          isLoaded ? 'opacity-100' : 'opacity-0'
+        )}
+        style={{
+          backgroundImage: imageData ? `url(${imageData.url})` : undefined,
+        }}
+      />
+
       {/* Enhanced gradient overlay */}
       <div
         className={cn(
@@ -68,13 +73,6 @@ export const QuoteCard: React.FC<QuoteCardProps> = React.memo(({ quote, classNam
 
       {/* Dark overlay for better readability */}
       <div className="absolute inset-0 bg-black/20" />
-
-      {/* Loading state with better animation */}
-      {loading && (
-        <div className="absolute inset-0 bg-black/10 flex items-center justify-center backdrop-blur-sm">
-          <div className="w-10 h-10 border-3 border-white/20 border-t-white rounded-full animate-spin" />
-        </div>
-      )}
 
       {/* Content with improved typography */}
       <div className="relative z-10 max-w-full mx-auto px-4">

--- a/src/hooks/useEndlessScroll.ts
+++ b/src/hooks/useEndlessScroll.ts
@@ -32,18 +32,18 @@ export const useEndlessScroll = (version: 'quotes' | 'psalms') => {
   const [page, setPage] = useState(0);
   const [shuffledQuotes, setShuffledQuotes] = useState<Quote[]>([]);
 
-  const QUOTES_PER_PAGE = 5;
+  const QUOTES_PER_PAGE = 6;
+  const PREFETCH_PAGES = 2;
 
   // Use refs to store state values that are used in callbacks, to avoid dependencies
-  const loadingRef = useRef(loading);
   const hasMoreRef = useRef(hasMore);
   const pageRef = useRef(page);
+  const isFetchingRef = useRef(false);
 
   useEffect(() => {
-    loadingRef.current = loading;
     hasMoreRef.current = hasMore;
     pageRef.current = page;
-  }, [loading, hasMore, page]);
+  }, [hasMore, page]);
 
 
   // Shuffle quotes on initial load and refresh
@@ -58,32 +58,35 @@ export const useEndlessScroll = (version: 'quotes' | 'psalms') => {
     }
   }, [localizedQuotes]);
 
-  const loadMoreQuotes = useCallback(() => {
-    if (loadingRef.current || !hasMoreRef.current || shuffledQuotes.length === 0) return;
+  const loadMoreQuotes = useCallback((showLoading = false) => {
+    if (isFetchingRef.current || !hasMoreRef.current || shuffledQuotes.length === 0) return;
 
-    setLoading(true);
-    
-    // Simulate API delay for better UX
-    setTimeout(() => {
-      const startIndex = pageRef.current * QUOTES_PER_PAGE;
-      const endIndex = startIndex + QUOTES_PER_PAGE;
-      const newQuotes = shuffledQuotes.slice(startIndex, endIndex);
-      
-      if (newQuotes.length === 0) {
-        setHasMore(false);
-      } else {
-        setQuotes(prev => [...prev, ...newQuotes]);
-        setPage(prev => prev + 1);
-      }
-      
+    isFetchingRef.current = true;
+    if (showLoading) {
+      setLoading(true);
+    }
+
+    const startIndex = pageRef.current * QUOTES_PER_PAGE;
+    const endIndex = startIndex + QUOTES_PER_PAGE;
+    const newQuotes = shuffledQuotes.slice(startIndex, endIndex);
+
+    if (newQuotes.length === 0) {
+      setHasMore(false);
+    } else {
+      setQuotes(prev => [...prev, ...newQuotes]);
+      setPage(prev => prev + 1);
+    }
+
+    if (showLoading) {
       setLoading(false);
-    }, 800);
+    }
+    isFetchingRef.current = false;
   }, [shuffledQuotes]);
 
   // Load initial quotes
   useEffect(() => {
     if (quotes.length === 0 && shuffledQuotes.length > 0) {
-      loadMoreQuotes();
+      loadMoreQuotes(true);
     }
   }, [loadMoreQuotes, quotes.length, shuffledQuotes.length]);
 
@@ -91,7 +94,7 @@ export const useEndlessScroll = (version: 'quotes' | 'psalms') => {
   useEffect(() => {
     if (shuffledQuotes.length > quotes.length) {
       const nextBatchStartIndex = quotes.length;
-      const nextBatchEndIndex = nextBatchStartIndex + QUOTES_PER_PAGE;
+      const nextBatchEndIndex = nextBatchStartIndex + QUOTES_PER_PAGE * PREFETCH_PAGES;
       const nextBatch = shuffledQuotes.slice(nextBatchStartIndex, nextBatchEndIndex);
 
       if (nextBatch.length > 0) {
@@ -108,7 +111,7 @@ export const useEndlessScroll = (version: 'quotes' | 'psalms') => {
   // Scroll event listener
   useEffect(() => {
     const handleScroll = throttle(() => {
-      if (window.innerHeight + document.documentElement.scrollTop >= document.documentElement.offsetHeight - 1000) {
+      if (window.innerHeight + document.documentElement.scrollTop >= document.documentElement.offsetHeight - 1600) {
         loadMoreQuotes();
       }
     }, 200);

--- a/src/hooks/useImageBackground.ts
+++ b/src/hooks/useImageBackground.ts
@@ -6,12 +6,14 @@ import { Quote } from '../data/quotes';
 export const useImageBackground = (quote: Quote | null) => {
   const [imageData, setImageData] = useState<ImageData | null>(null);
   const [loading, setLoading] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
     if (!quote) return;
 
     const fetchImage = async () => {
       setLoading(true);
+      setIsLoaded(false);
       try {
         const image = await imageService.getImageForQuote(quote.text, quote.category);
         setImageData(image);
@@ -19,7 +21,7 @@ export const useImageBackground = (quote: Quote | null) => {
         console.error('Error fetching background image:', error);
         // Use a default fallback
         setImageData({
-          url: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80',
+          url: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?ixlib=rb-4.0.3&auto=format&fit=crop&w=1600&q=80',
           photographer: 'Unsplash',
           source: 'fallback',
           id: 'default'
@@ -38,5 +40,27 @@ export const useImageBackground = (quote: Quote | null) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [quote?.id, quote?.text, quote?.category]);
 
-  return { imageData, loading };
+  useEffect(() => {
+    if (!imageData?.url) return;
+
+    let isActive = true;
+    const img = new Image();
+    img.src = imageData.url;
+    img.onload = () => {
+      if (isActive) {
+        setIsLoaded(true);
+      }
+    };
+    img.onerror = () => {
+      if (isActive) {
+        setIsLoaded(true);
+      }
+    };
+
+    return () => {
+      isActive = false;
+    };
+  }, [imageData?.url]);
+
+  return { imageData, loading, isLoaded };
 };

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -2,6 +2,7 @@
 // Unsplash API service for fetching dynamic background images
 const UNSPLASH_ACCESS_KEY = 'YOUR_UNSPLASH_ACCESS_KEY'; // User will need to get this
 const UNSPLASH_API_URL = 'https://api.unsplash.com';
+const IMAGE_WIDTH = 1600;
 
 // Fallback images from our placeholder collection
 const FALLBACK_IMAGES = [
@@ -56,7 +57,7 @@ class ImageService {
     if (typeof window !== 'undefined') {
       FALLBACK_IMAGES.forEach(id => {
         const img = new Image();
-        img.src = `https://images.unsplash.com/${id}?ixlib=rb-4.0.3&auto=format&fit=crop&w=600&q=80`;
+        img.src = `https://images.unsplash.com/${id}?ixlib=rb-4.0.3&auto=format&fit=crop&w=${IMAGE_WIDTH}&q=80`;
       });
     }
   }
@@ -91,7 +92,7 @@ class ImageService {
   private getFallbackImage(): ImageData {
     const randomId = FALLBACK_IMAGES[Math.floor(Math.random() * FALLBACK_IMAGES.length)];
     return {
-      url: `https://images.unsplash.com/${randomId}?ixlib=rb-4.0.3&auto=format&fit=crop&w=600&q=80`,
+      url: `https://images.unsplash.com/${randomId}?ixlib=rb-4.0.3&auto=format&fit=crop&w=${IMAGE_WIDTH}&q=80`,
       photographer: 'Unsplash',
       source: 'fallback',
       id: randomId


### PR DESCRIPTION
### Motivation
- Reduce visible loading jank during scrolling by batching loads and prefetching additional images ahead of the viewport. 
- Ensure quote background imagery appears smoothly without abrupt pop-in by waiting for images to load before showing them. 
- Improve visual quality of fallback backgrounds by increasing their resolution.

### Description
- Increased page size from `QUOTES_PER_PAGE = 5` to `6` and added `PREFETCH_PAGES = 2` to prefetch more images for upcoming batches in `useEndlessScroll.ts`.
- Added `isFetchingRef` and a `showLoading` flag to `loadMoreQuotes` to prevent concurrent fetches and make initial load show a loading state only when appropriate in `useEndlessScroll.ts`.
- Extended the scroll prefetch trigger to `-1600`px to load content earlier and reduced on-screen loading by preloading `QUOTES_PER_PAGE * PREFETCH_PAGES` images via `imageService` in `useEndlessScroll.ts`.
- Added image load tracking (`isLoaded`) to `useImageBackground.ts` and introduced an explicit preloaded `Image` instance to detect when the background URL has finished loading.
- Reworked `QuoteCard.tsx` to render a dedicated background layer that uses `isLoaded` to fade images in smoothly over the gradient and removed the previous inline background pop-in behavior.
- Increased fallback image width by introducing `IMAGE_WIDTH = 1600` and using it for preloads and fallback URLs in `imageService.ts` to improve background sharpness.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server came up and served the app successfully. 
- Ran a Playwright smoke script that navigated to `http://127.0.0.1:4173/en/quotes`, scrolled the page, and captured a screenshot at `artifacts/quotes-scroll.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8562045c8325be344374c14d70da)